### PR TITLE
Add Uuidrepresentation parameter

### DIFF
--- a/backend/src/db/db_init.py
+++ b/backend/src/db/db_init.py
@@ -1,4 +1,5 @@
 from mongoengine import connect
+from bson.binary import UuidRepresentation
 from dotenv import dotenv_values
 
 def init_db():
@@ -8,5 +9,7 @@ def init_db():
         username= config["MONGO_USER"],
         password= config["MONGO_PASSWORD"],
         host= config["MONGO_HOST"],
-        port= int(config["MONGO_PORT"])
+        port= int(config["MONGO_PORT"],
+        uuidRepresentation=UuidRepresentation.STANDARD
+        )
     )


### PR DESCRIPTION
Added UUID representation parameter when connecting to DB
This is done because of the warning:
`DeprecationWarning: No uuidRepresentation is specified! Falling back to 'pythonLegacy' which is the default for pymongo 3.x. For compatibility with other MongoDB drivers this should be specified as 'standard' or '{java,csharp}Legacy' to work with older drivers in those languages. This will be changed to 'unspecified' in a future release.`

